### PR TITLE
feat(auth): connect login/register UI to backend API

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
@@ -9,6 +10,8 @@ export const appConfig: ApplicationConfig = {
     // Registra tratamento global de erros em runtime.
     provideBrowserGlobalErrorListeners(),
     // Habilita o roteador com as rotas definidas em app.routes.ts.
-    provideRouter(routes)
+    provideRouter(routes),
+    // Habilita HttpClient para chamadas HTTP ao backend.
+    provideHttpClient(),
   ]
 };

--- a/frontend/src/app/auth/auth.service.ts
+++ b/frontend/src/app/auth/auth.service.ts
@@ -1,0 +1,55 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, tap } from 'rxjs';
+
+export interface RegisterRequest {
+  username: string;
+  email: string;
+  password: string;
+}
+
+export interface LoginRequest {
+  username: string;
+  password: string;
+}
+
+export interface AuthResponse {
+  token: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly apiUrl = 'http://localhost:8080/api/auth';
+
+  constructor(private http: HttpClient) {}
+
+  register(data: RegisterRequest): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.apiUrl}/register`, data).pipe(
+      tap((res) => this.saveToken(res.token))
+    );
+  }
+
+  login(data: LoginRequest): Observable<AuthResponse> {
+    return this.http.post<AuthResponse>(`${this.apiUrl}/login`, data).pipe(
+      tap((res) => this.saveToken(res.token))
+    );
+  }
+
+  logout(): void {
+    localStorage.removeItem('token');
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem('token');
+  }
+
+  isLoggedIn(): boolean {
+    return !!this.getToken();
+  }
+
+  private saveToken(token: string): void {
+    localStorage.setItem('token', token);
+  }
+}

--- a/frontend/src/app/auth/login/login.css
+++ b/frontend/src/app/auth/login/login.css
@@ -129,6 +129,16 @@
   color: #f44;
 }
 
+.error-banner {
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(255, 68, 68, 0.12);
+  border: 1px solid rgba(255, 68, 68, 0.35);
+  color: #f66;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 /* Linha auxiliar de opções (lembrar + recuperação de senha). */
 .form-row {
   display: flex;

--- a/frontend/src/app/auth/login/login.html
+++ b/frontend/src/app/auth/login/login.html
@@ -11,19 +11,19 @@
 
     <!-- Formulário -->
     <form [formGroup]="loginForm" (ngSubmit)="onSubmit()" class="auth-form">
-      <!-- E-mail -->
+      <!-- Username -->
       <div class="form-group">
-        <label for="email" class="form-label">Email</label>
+        <label for="username" class="form-label">Username</label>
         <input
-          id="email"
-          type="email"
-          formControlName="email"
-          placeholder="you@email.com"
+          id="username"
+          type="text"
+          formControlName="username"
+          placeholder="Your callsign"
           class="form-input"
-          [class.input-error]="hasError('email')"
+          [class.input-error]="hasError('username')"
         />
-        @if (hasError('email')) {
-          <span class="error-msg">{{ getErrorMessage('email') }}</span>
+        @if (hasError('username')) {
+          <span class="error-msg">{{ getErrorMessage('username') }}</span>
         }
       </div>
 
@@ -65,6 +65,11 @@
         </label>
         <a routerLink="/forgot-password" class="link-subtle">Forgot password?</a>
       </div>
+
+      <!-- Erro do backend -->
+      @if (errorMessage()) {
+        <div class="error-banner">{{ errorMessage() }}</div>
+      }
 
       <!-- Submit -->
       <button type="submit" class="btn-submit" [disabled]="isLoading()">

--- a/frontend/src/app/auth/login/login.ts
+++ b/frontend/src/app/auth/login/login.ts
@@ -2,6 +2,7 @@ import { Component, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../auth.service';
 
 // Componente de login: valida formulário e controla fluxo de submissão.
 @Component({
@@ -17,11 +18,13 @@ export class LoginComponent {
   isLoading = signal(false);
   // Controla exibição/ocultação da senha no input.
   showPassword = signal(false);
+  // Mensagem de erro vinda do backend.
+  errorMessage = signal('');
 
-  constructor(private fb: FormBuilder, private router: Router) {
+  constructor(private fb: FormBuilder, private router: Router, private authService: AuthService) {
     // Estrutura e validações do formulário.
     this.loginForm = this.fb.group({
-      email: ['', [Validators.required, Validators.email]],
+      username: ['', [Validators.required, Validators.minLength(3)]],
       password: ['', [Validators.required, Validators.minLength(6)]],
       rememberMe: [false],
     });
@@ -44,27 +47,28 @@ export class LoginComponent {
     if (!control || !control.errors || !control.touched) return '';
 
     if (control.errors['required']) {
-      return field === 'email' ? 'Email is required' : 'Password is required';
+      return field === 'username' ? 'Username is required' : 'Password is required';
     }
-    if (control.errors['email']) return 'Invalid email';
-    if (control.errors['minlength']) return 'Minimum 6 characters';
+    if (control.errors['minlength']) return `Minimum ${control.errors['minlength'].requiredLength} characters`;
 
     return '';
   }
 
-  // Executa submit: valida formulário, aplica loading e navega após sucesso.
-  async onSubmit(): Promise<void> {
+  // Executa submit: chama AuthService e navega após sucesso.
+  onSubmit(): void {
     this.loginForm.markAllAsTouched();
     if (this.loginForm.invalid) return;
 
     this.isLoading.set(true);
+    this.errorMessage.set('');
 
-    try {
-      // TODO: integrar com AuthService
-      console.log('Login:', this.loginForm.value);
-      await this.router.navigate(['/']);
-    } finally {
-      this.isLoading.set(false);
-    }
+    const { username, password } = this.loginForm.value;
+    this.authService.login({ username, password }).subscribe({
+      next: () => this.router.navigate(['/']),
+      error: (err) => {
+        this.errorMessage.set(err.error?.error ?? 'Login failed. Check your credentials.');
+        this.isLoading.set(false);
+      },
+    });
   }
 }

--- a/frontend/src/app/auth/register/register.css
+++ b/frontend/src/app/auth/register/register.css
@@ -129,6 +129,16 @@
   color: #f44;
 }
 
+.error-banner {
+  padding: 10px 14px;
+  border-radius: 8px;
+  background: rgba(255, 68, 68, 0.12);
+  border: 1px solid rgba(255, 68, 68, 0.35);
+  color: #f66;
+  font-size: 0.85rem;
+  text-align: center;
+}
+
 /* Bloco de aceite de termos. */
 .checkbox-label {
   display: flex;

--- a/frontend/src/app/auth/register/register.html
+++ b/frontend/src/app/auth/register/register.html
@@ -117,6 +117,11 @@
         }
       </div>
 
+      <!-- Erro do backend -->
+      @if (errorMessage()) {
+        <div class="error-banner">{{ errorMessage() }}</div>
+      }
+
       <!-- Submit -->
       <button type="submit" class="btn-submit" [disabled]="isLoading()">
         @if (isLoading()) {

--- a/frontend/src/app/auth/register/register.ts
+++ b/frontend/src/app/auth/register/register.ts
@@ -9,6 +9,7 @@ import {
   ValidationErrors,
 } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
+import { AuthService } from '../auth.service';
 
 // Componente de cadastro: valida dados, confirma senha e envia formulário.
 @Component({
@@ -26,7 +27,10 @@ export class RegisterComponent {
   showPassword = signal(false);
   showConfirmPassword = signal(false);
 
-  constructor(private fb: FormBuilder, private router: Router) {
+  // Mensagem de erro vinda do backend.
+  errorMessage = signal('');
+
+  constructor(private fb: FormBuilder, private router: Router, private authService: AuthService) {
     // Define controles, validações e validação de grupo (senha x confirmação).
     this.registerForm = this.fb.group(
       {
@@ -94,19 +98,21 @@ export class RegisterComponent {
     return '';
   }
 
-  // Executa submit: valida formulário, controla loading e redireciona ao final.
-  async onSubmit(): Promise<void> {
+  // Executa submit: chama AuthService e redireciona após criar conta.
+  onSubmit(): void {
     this.registerForm.markAllAsTouched();
     if (this.registerForm.invalid) return;
 
     this.isLoading.set(true);
+    this.errorMessage.set('');
 
-    try {
-      // TODO: integrar com AuthService
-      console.log('Register:', this.registerForm.value);
-      await this.router.navigate(['/login']);
-    } finally {
-      this.isLoading.set(false);
-    }
+    const { name, email, password } = this.registerForm.value;
+    this.authService.register({ username: name, email, password }).subscribe({
+      next: () => this.router.navigate(['/']),
+      error: (err) => {
+        this.errorMessage.set(err.error?.error ?? 'Registration failed. Try again.');
+        this.isLoading.set(false);
+      },
+    });
   }
 }


### PR DESCRIPTION
## Summary
Wires the existing login and register pages to the Spring Boot backend (`/api/auth`).

## Changes
- **`auth.service.ts`** – new service that calls `POST /api/auth/register` and `POST /api/auth/login`, stores the JWT in `localStorage`
- **`login.ts` / `login.html`** – replaced `email` field with `username` to match the backend contract; integrated `AuthService`; shows backend error messages
- **`register.ts`** – integrated `AuthService`; maps form `name` field to `username`; shows backend error messages
- **`register.html`** – added error banner for backend errors
- **`app.config.ts`** – added `provideHttpClient()` so Angular HTTP works

## How to test
1. Start the backend: `./mvnw spring-boot:run` (with Neon env vars)
2. Start the frontend: `npm start`
3. Go to `http://localhost:4200/register` and create an account
4. Confirm the user appears in the Neon dashboard → Tables → `users`
5. Log in at `http://localhost:4200/login` and confirm redirect to home

## Notes
- Backend lives in the `backend` branch — run both in separate terminals
- CORS is already configured for `http://localhost:4200`